### PR TITLE
Contadores de OTHs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 .DS_Store
 
 application/cache/*
@@ -30,6 +29,5 @@ user_guide_src/cilexer/pycilexer.egg-info/*
 *.sublime-project
 /tests/tests/
 /tests/results/
-=======
 /nbproject/private/
->>>>>>> 6c099300e4c3520bad325ac7c9136e4eb7de52a0
+.vscode/

--- a/application/models/data/Dao_ot_padre_model.php
+++ b/application/models/data/Dao_ot_padre_model.php
@@ -71,15 +71,18 @@ class Dao_ot_padre_model extends CI_Model {
                 otp.servicio, REPLACE(otp.estado_orden_trabajo,'otp_cerrada','Cerrada') AS estado_orden_trabajo, otp.fecha_programacion,
                 otp.fecha_compromiso, otp.fecha_creacion, otp.k_id_user, user.n_name_user,
                 CONCAT(user.n_name_user, ' ' , user.n_last_name_user) AS ingeniero,
-                otp.lista_observaciones, otp.observacion, SUM(oth.c_email) AS cant_mails, hitos.id_hitos, otp.finalizo, otp.ultimo_envio_reporte,
-                CONCAT('$ ',FORMAT(oth.monto_moneda_local_arriendo + oth.monto_moneda_local_cargo_mensual,2)) AS MRC, otp.lista_observaciones
+                otp.lista_observaciones, otp.observacion, IFNULL(SUM( oth.c_email ),0) AS cant_mails, hitos.id_hitos, otp.finalizo, otp.ultimo_envio_reporte,
+                CONCAT('$ ',FORMAT(oth.monto_moneda_local_arriendo + oth.monto_moneda_local_cargo_mensual,2)) AS MRC, otp.lista_observaciones,
+                (SELECT COUNT(oth2.nro_ot_onyx) FROM ot_hija oth2 WHERE otp.k_id_ot_padre = oth2.nro_ot_onyx ) AS cant_oths
                 FROM ot_hija oth
-                INNER JOIN ot_padre otp ON oth.nro_ot_onyx = otp.k_id_ot_padre
+                -- INNER JOIN ot_padre otp ON oth.nro_ot_onyx = otp.k_id_ot_padre
+                RIGHT JOIN ot_padre otp ON oth.nro_ot_onyx = otp.k_id_ot_padre
                 INNER JOIN user ON otp.k_id_user = user.k_id_user
                 LEFT JOIN hitos ON hitos.id_ot_padre = otp.k_id_ot_padre
                 $condicion
                 GROUP BY nro_ot_onyx
         ");
+        // echo("<pre>"); print_r($this->db->last_query()); echo("</pre>");
         return $query;
     }
 

--- a/application/views/work_managementOtp.php
+++ b/application/views/work_managementOtp.php
@@ -65,6 +65,7 @@
                     <th></th>
                     <th></th>
                     <th></th>
+                    <th></th>
                     <th id="opciones"></th>
                 </tr>
             </tfoot>

--- a/assets/css/vertical_tabs.css
+++ b/assets/css/vertical_tabs.css
@@ -68,3 +68,14 @@ div.bhoechie-tab-content{
 div.bhoechie-tab div.bhoechie-tab-content:not(.active){
   display: none;
 }
+
+#table_otPadreList tbody tr td{
+  vertical-align: middle !important;
+}
+.styleNum{
+  font-size: 1.8em;
+  border-radius:4px;
+  background: #2499d6db;
+  display: block;
+  color: #ffffff;
+}

--- a/assets/js/modules/moduleOtpadre.js
+++ b/assets/js/modules/moduleOtpadre.js
@@ -266,20 +266,20 @@ $(function() {
         },
         //Eventos de la ventana.
         events: function() {
-
+        
         },
         getListOtsOtPadre: function() {
             //metodo ajax (post)
             $.post(baseurl + '/OtPadre/c_getListOtsOtPadre',
                     {
                         //parametros
-
+                        
                     },
                     // funcion que recibe los datos
                             function(data) {
                                 // convertir el json a objeto de javascript
                                 var obj = JSON.parse(data);
-                                vista.printTable(obj.data);
+                                vista.printTable(obj.data);   
                                 if (obj.cantOTPs > 0) {
                                     $('#badge_cant_total_OTP').html(obj.cantOTPs);
                                 }
@@ -303,8 +303,21 @@ $(function() {
                 {title: "Observaciónes dejadas", data: gral.inputObservaciones},
                 {title: "Recurrente", data: "MRC", visible: false},
                 {title: "ultimo envio", data: gral.cant_dias_ultimo_reporte, visible: false},
+                {title: "No. OTHs", data: vista.getColourPerOTHs},
                 {title: "Opc", data: vista.getButtonsOTP/**/},
             ]));
+            
+        },
+        
+        getColourPerOTHs: function (data){
+            let num = '';
+            if (data.cant_oths != 0) {
+                num += `<span class="styleNum" title="${data.cant_oths} OTHs Asociadas" >${data.cant_oths}</span>`;
+            } else {
+                num += `<span class="styleNum noOTHs" title="sin OTHs">${data.cant_oths}</span>`;
+            }
+            
+            return num;
         },
         // Datos de configuracion del datatable
         configTable: function(data, columns, onDraw) {
@@ -388,7 +401,12 @@ $(function() {
                         orderable: false,
                     }],
                 order: [[7, 'desc']],
-                drawCallback: onDraw
+                drawCallback: onDraw,
+                "createdRow": function(row, data, dataIndex) {
+                    if (data["cant_oths"] == 0) {
+                        $(row).css("background-color", "#f50e0e69");
+                    }
+                },
             }
         },
 


### PR DESCRIPTION
con este cambio relacionado al issue #3 se pretendía colocar en la pestaña de Mannagement, todas las OTPs sin importar si tienen o no OTHs asociadas
de esta manera tambien agregar un contador de OTHs asociadas en la columna para conocer si entrar a las OTHs, cuántas tiene.
También cabe recalcar que si no tiene ninguna OTH asociada, la fila en cuestión será pintada de un rojo, para identificarlas fácilmente