### PR TITLE
No cerrar las otp al momento de cargar la data

### DIFF
--- a/application/controllers/LoadInformation.php
+++ b/application/controllers/LoadInformation.php
@@ -261,6 +261,7 @@ class LoadInformation extends CI_Controller {
                                 array_push($errorNoChange, array($sinCambios, $this->getValueCell($sheet, 'AW' . $row)));
                             }
                         }
+                        //print_r($updates);
                         if ($updates) {
                             $up_otp = [];
                             $up_oth = [];
@@ -313,6 +314,7 @@ class LoadInformation extends CI_Controller {
                                 'fecha_actualizacion'   => NULL,
                                 'usuario_actualizacion' => NULL,
                             );
+                            //print_r('data'.$dataotp);
                             // funcion para insertar datos otp
                             $this->Dao_ot_padre_model->insert_data_otp($dataotp);
                         }

--- a/application/models/data/Dao_ot_padre_model.php
+++ b/application/models/data/Dao_ot_padre_model.php
@@ -619,10 +619,11 @@ class Dao_ot_padre_model extends CI_Model {
                     AND otp1.k_id_user = u.k_id_user
                     AND otp1.n_nombre_cliente NOT IN ('BANCO COLPATRIA RED MULTIBANCA COLPATRIA S.A', 'BANCO DAVIVIENDA S.A', 'SERVIBANCA S.A.')
                     AND otp1.orden_trabajo != 'Caso de Seguimiento'
+                    /* si solo se quiere mostrar otp que tengan oth descomentariar esta seccion
                     AND EXISTS(
                         SELECT nro_ot_onyx FROM ot_hija AS oth1
                         WHERE otp1.k_id_ot_padre = oth1.nro_ot_onyx
-                    )
+                    )*/
 
                 ) AS menor_7,
                 (
@@ -632,10 +633,11 @@ class Dao_ot_padre_model extends CI_Model {
                     AND otp2.k_id_user = u.k_id_user
                     AND otp2.n_nombre_cliente NOT IN ('BANCO COLPATRIA RED MULTIBANCA COLPATRIA S.A', 'BANCO DAVIVIENDA S.A', 'SERVIBANCA S.A.')
                     AND otp2.orden_trabajo != 'Caso de Seguimiento'
+                    /* si solo se quiere mostrar otp que tengan oth descomentariar esta seccion
                     AND EXISTS(
                         SELECT nro_ot_onyx FROM ot_hija AS oth2
                         WHERE otp2.k_id_ot_padre = oth2.nro_ot_onyx
-                    )
+                    )*/
 
                 ) AS entre_8_15,
                 (
@@ -645,10 +647,11 @@ class Dao_ot_padre_model extends CI_Model {
                     AND otp3.k_id_user = u.k_id_user
                     AND otp3.n_nombre_cliente NOT IN ('BANCO COLPATRIA RED MULTIBANCA COLPATRIA S.A', 'BANCO DAVIVIENDA S.A', 'SERVIBANCA S.A.')
                     AND otp3.orden_trabajo != 'Caso de Seguimiento'
+                    /* si solo se quiere mostrar otp que tengan oth descomentariar esta seccion
                     AND EXISTS(
                         SELECT nro_ot_onyx FROM ot_hija AS oth3
                         WHERE otp3.k_id_ot_padre = oth3.nro_ot_onyx
-                    )
+                    )*/
 
                 ) AS entre_16_30,
                 (
@@ -657,10 +660,11 @@ class Dao_ot_padre_model extends CI_Model {
                     AND otp4.k_id_user = u.k_id_user
                     AND otp4.n_nombre_cliente NOT IN ('BANCO COLPATRIA RED MULTIBANCA COLPATRIA S.A', 'BANCO DAVIVIENDA S.A', 'SERVIBANCA S.A.')
                     AND otp4.orden_trabajo != 'Caso de Seguimiento'
+                    /* si solo se quiere mostrar otp que tengan oth descomentariar esta seccion
                     AND EXISTS(
                         SELECT nro_ot_onyx FROM ot_hija AS oth4
                         WHERE otp4.k_id_ot_padre = oth4.nro_ot_onyx
-                    )
+                    )*/
 
                 ) AS mayor_30
             FROM user u


### PR DESCRIPTION
para el issue #1 se verifica que al momento de cargar la data no se estan eliminado las ot padres, se modifica la consulta de la tabla de contadores de la pestaña de enviar reportes para que traiga las ot padre que no tengan ot hijas asociadas